### PR TITLE
fix mayhem target parameters

### DIFF
--- a/mayhem/hayabusa.mayhemfile
+++ b/mayhem/hayabusa.mayhemfile
@@ -2,5 +2,7 @@ project: hayabusa
 target: hayabusa
 
 cmds:
-  - cmd: /hayabusa --rules /rules --file /fuzz.evtx
+  - cmd: /hayabusa --rules /rules/hayabusa/default/ --file /fuzz.evtx
     filepath: /fuzz.evtx
+    timeout: 15
+    max_length: 52428800


### PR DESCRIPTION
The program loads detection/scanning rules during startup, and the main `rules` directory has a lot of rules that are not as well optimized. So I limited it to the default ruleset.

`timeout: 15` seems to not be necessary anymore, I can remove it if needed, but this is a somewhat slow target anyway

`max_length: 50MB`: windows evtx files can get big, and the sample corpus I provide has one that is 30MB